### PR TITLE
chore: set pack default to v0.13.1

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -25,7 +25,7 @@ jobs:
         default: ""
       version:
         type: string
-        default: 0.11.2
+        default: 0.13.1
     steps:
       - run: sudo chown -R circleci /var/lib/docker/volumes
       - install-pack:

--- a/orb.yml
+++ b/orb.yml
@@ -83,7 +83,7 @@ commands:
         type: string
       version:
         type: string
-        default: 0.10.0
+        default: 0.13.1
     steps:
       - run:
           name: "Setup and install pack"


### PR DESCRIPTION
Update to the latest version of `pack`.


Here's a [link](https://app.circleci.com/pipelines/github/elbandito/pack-orb-tester/8/workflows/fc73bb9a-ded8-4955-80d9-e5d7883788ec/jobs/11) to a sample project that uses the changes in this PR to build with version `0.13.1`.