### PR TITLE
Add integrations tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,19 +1,50 @@
 version: 2.1
 orbs:
   orb-tools: circleci/orb-tools@9.1.0
+  buildpacks: buildpacks/pack@<<pipeline.parameters.dev-orb-version>>
+
+# Pipeline Parameters
+parameters:
+  ## internal to orb-tools
+  run-integration-tests:
+    description: An internal flag to prevent integration test from running before a development version has been created.
+    type: boolean
+    default: false
+  ## internal to orb-tools
+  dev-orb-version:
+    description: >
+      The development version of the orb to test.
+      This value is automatically adjusted by the "trigger-integration-tests-workflow" job to correspond with the specific version created by the commit and should not be edited.
+      A "dev:alpha" version must exist for the initial pipeline run.
+    type: string
+    default: "dev:alpha"
 
 workflows:
+  integration-test:
+    when: << pipeline.parameters.run-integration-tests >>
+    jobs:
+      - buildpacks/build:
+          working-directory: samples/apps/ruby-bundler
+          image-name: test-image
+          builder: heroku/buildpacks:18
+          after-checkout:
+            - run: git clone --depth=1 https://github.com/buildpacks/samples.git samples
   validate-dev:
+    unless: << pipeline.parameters.run-integration-tests >>
     jobs:
       - orb-tools/lint
+      - orb-tools/pack
       - orb-tools/publish-dev:
           orb-name: buildpacks/pack
-          orb-path: orb.yml
-          publish-token-variable: CIRCLE_TOKEN
-          checkout: true
           requires:
             - orb-tools/lint
+            - orb-tools/pack
+      - orb-tools/trigger-integration-tests-workflow:
+          name: trigger-integration-dev
+          requires:
+            - orb-tools/publish-dev
   draft-release:
+    unless: << pipeline.parameters.run-integration-tests >>
     jobs:
       - hold-for-approval:
           filters:
@@ -27,11 +58,10 @@ workflows:
           requires:
             - hold-for-approval
   publish:
+    unless: << pipeline.parameters.run-integration-tests >>
     jobs:
       - orb-tools/publish:
           orb-ref: buildpacks/pack@$CIRCLE_TAG
-          orb-path: orb.yml
-          publish-token-variable: CIRCLE_TOKEN
           filters:
             branches:
               ignore: /.*/

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,0 +1,12 @@
+
+
+### Prerequisites
+
+- Make
+- [circle CLI](https://circleci.com/docs/2.0/local-cli/#installation)
+
+### Testing
+
+```
+make lint
+```

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,5 @@
+
+.PHONY: validate
+lint:
+	circleci orb pack src/ | circleci orb validate -
+	circleci config validate .circleci/config.yml

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -5,9 +5,6 @@ display:
   source_url: "https://github.com/buildpacks/pack-orb"
   home_url: "https://buildpacks.io/"
 
-orbs:
-  docker: circleci/docker@1.2.1
-  orb-tools: circleci/orb-tools@9.1.0
 jobs:
   build:
     description: "Build OCI Image"
@@ -40,6 +37,10 @@ jobs:
         type: string
         description: Version of 'pack' to use.
         default: 0.13.1
+      after-checkout:
+        description: Optional steps to run after checking out the code.
+        type: steps
+        default: []
       executor-image:
         type: string
         description: Image to execute 'pack' in.
@@ -49,6 +50,10 @@ jobs:
       - install-pack:
           version: << parameters.version >>
       - checkout
+      - when:
+          name: Run after-checkout lifecycle hook steps.
+          condition: << parameters.after-checkout >>
+          steps: << parameters.after-checkout >>
       - pack-build:
           working-directory: << parameters.working-directory >>
           image-name: << parameters.image-name >>
@@ -144,56 +149,3 @@ commands:
             if [ ! -f ~/.docker/config.json ]; then
               echo "{}" > ~/.docker/config.json
             fi
-
-examples:
-  heroku:
-    description: Run the Heroku Buildpacks
-    usage:
-      version: 2.1
-      orbs:
-        buildpacks: buildpacks/pack@x.y.z
-      workflows:
-        main:
-          jobs:
-            - buildpacks/build:
-                image-name: myimage
-                builder: heroku/buildpacks:18
-  use-buildpack:
-    description: Run the Heroku Buildpacks
-    usage:
-      version: 2.1
-      orbs:
-        buildpacks: buildpacks/pack@x.y.z
-      workflows:
-        main:
-          jobs:
-            - buildpacks/build:
-                image-name: myimage
-                builder: heroku/buildpacks:18
-                buildpack: heroku/ruby
-  build-and-publish:
-    description: Run the Heroku Buildpacks
-    usage:
-      version: 2.1
-      orbs:
-        buildpacks: buildpacks/pack@x.y.z
-      jobs:
-        publish:
-          machine: true
-          steps:
-            - attach_workspace:
-                at: /tmp/workspace
-            - run:
-                command: |
-                  docker load -i /tmp/workspace/images/myimage.tgz
-                  docker push myimage
-      workflows:
-        main:
-          jobs:
-            - buildpacks/build:
-                image-name: myimage
-                image-file: myimage.tgz
-                builder: heroku/buildpacks:18
-            - publish:
-                requires:
-                  - buildpacks/build

--- a/src/examples/basic.yml
+++ b/src/examples/basic.yml
@@ -1,0 +1,12 @@
+description: Basic usage
+
+usage:
+  version: 2.1
+  orbs:
+    buildpacks: buildpacks/pack@x.y.z
+  workflows:
+    main:
+      jobs:
+        - buildpacks/build:
+            image-name: myimage
+            builder: heroku/buildpacks:18

--- a/src/examples/build-and-publish.yml
+++ b/src/examples/build-and-publish.yml
@@ -1,0 +1,26 @@
+description: Build and publish
+
+usage:
+  version: 2.1
+  orbs:
+    buildpacks: buildpacks/pack@x.y.z
+  workflows:
+    main:
+      jobs:
+        - buildpacks/build:
+            image-name: myimage
+            image-file: myimage.tgz
+            builder: heroku/buildpacks:18
+        - publish:
+            requires:
+              - buildpacks/build
+  jobs:
+    publish:
+      machine: true
+      steps:
+        - attach_workspace:
+            at: /tmp/workspace
+        - run:
+            command: |
+              docker load -i /tmp/workspace/images/myimage.tgz
+              docker push myimage

--- a/src/examples/explicit-buildpacks.yml
+++ b/src/examples/explicit-buildpacks.yml
@@ -1,0 +1,13 @@
+description: Run specific buildpacks
+
+usage:
+  version: 2.1
+  orbs:
+    buildpacks: buildpacks/pack@x.y.z
+  workflows:
+    main:
+      jobs:
+        - buildpacks/build:
+            image-name: myimage
+            builder: heroku/buildpacks:18
+            buildpack: heroku/ruby


### PR DESCRIPTION
## Summary

Added integration tests on circleci. This required the addition of a hook (`after_checkout`) in order to be able to checkout additional sources to use during the integration test. This "feature" could prove to be helpful to users in order to do additional operations on the source before buildings. As an example, see [this kaniko orb](https://circleci.com/developer/orbs/orb/glenjamin/kaniko-publish).

Additionally, unnecessary orbs were removed from original orb definition as per https://github.com/buildpacks/pack-orb/issues/25.

Resolves #25 