### PR TITLE
Add workflow to update default pack version

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -1,0 +1,26 @@
+name: update-pack-version
+
+on:
+  repository_dispatch:
+    types:
+      - pack-release
+
+jobs:
+  update-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update pack version of buildpacks/pack-orb/src/@orb.yml on new pack release
+        uses: actions/checkout@v2
+        run: |
+            NEW_VERSION = $(curl -s -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/buildpacks/pack/releases/latest | jq .tag_name -r | cut -c 2-)
+            sed -if "s/default: [0-9]\{1,\}.[0-9]\{1,\}.[0-9]\{1,\}/default: "$NEW_VERSION"/g" src/@orb.yml
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v3.10.0
+        with:
+          token: ${{ secrets.DISTRIBUTION_GITHUB_TOKEN }}
+          commit-message: Update version to latest release of buildpacks/pack
+          title: Update default version of @orb.yml
+          body: Updates default version of @orb.yml to reflect release changes in buildpacks/pack
+          branch: update-version
+          base: main
+          signoff: true


### PR DESCRIPTION
This is to create a PR to update the default pack version in pack-orb/src/@orb.yml when a new pack version is released.
References [update-version-on-release-ga.yml](https://github.com/buildpacks/registry-index/blob/main/.github/workflows/update-version-on-release-ga.yaml). 

Will create a similar action for the github-actions repository after this workflow is approved, as they will utilize similar logic.

Issue: [pack #1244](https://github.com/buildpacks/pack/issues/1244)
Related PR(s): [pack #1263](https://github.com/buildpacks/pack/pull/1263)