### PR TITLE
Remove -f flag from sed script

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
         run: |
             NEW_VERSION = $(curl -s -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/buildpacks/pack/releases/latest | jq .tag_name -r | cut -c 2-)
-            sed -if "s/default: [0-9]\{1,\}.[0-9]\{1,\}.[0-9]\{1,\}/default: "$NEW_VERSION"/g" src/@orb.yml
+            sed -i "s/default: [0-9]\{1,\}.[0-9]\{1,\}.[0-9]\{1,\}/default: "$NEW_VERSION"/g" src/@orb.yml
       - name: Create pull request
         uses: peter-evans/create-pull-request@v3.10.0
         with:


### PR DESCRIPTION
Why this change:

The script I added was derived from macOS. I learnt that the default sed version works differently on macOS and linux. After checking for linux, the -f flag is unnecessary. Although it results in the same changes upon running, I'd like to avoid any unforeseen consequences this may have.