### PR TITLE
Fix update-version.yml

### DIFF
--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -9,8 +9,8 @@ jobs:
   update-version:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
       - name: Update pack version of buildpacks/pack-orb/src/@orb.yml on new pack release
-        uses: actions/checkout@v2
         run: |
             NEW_VERSION = $(curl -s -H "Accept: application/vnd.github.v3+json" https://api.github.com/repos/buildpacks/pack/releases/latest | jq .tag_name -r | cut -c 2-)
             sed -i "s/default: [0-9]\{1,\}.[0-9]\{1,\}.[0-9]\{1,\}/default: "$NEW_VERSION"/g" src/@orb.yml


### PR DESCRIPTION
Signed-off-by: Ujjwal Goyal <importujjwal@gmail.com>

Reason for update:

A similar workflow in the [github-actions repo](https://github.com/buildpacks/github-actions/actions/runs/1167272814) was failing as it had `uses` and `run` keys in the same step. This should resolve the issue.