### PR TITLE
Add retries, timeouts and status code checking to curl usages

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -85,7 +85,7 @@ commands:
           name: "Setup and install pack"
           command: |
             mkdir -p << parameters.install-dir >>
-            curl -L "https://github.com/buildpack/pack/releases/download/v<< parameters.version >>/pack-v<< parameters.version >>-linux.tgz" | tar xzm -C << parameters.install-dir >>
+            curl -L --fail --retry 3 --connect-timeout 5 --max-time 60 "https://github.com/buildpack/pack/releases/download/v<< parameters.version >>/pack-v<< parameters.version >>-linux.tgz" | tar xzm -C << parameters.install-dir >>
             export PATH="$PATH:<< parameters.install-dir >>"
             mkdir -p ~/.docker/
             if [ ! -f ~/.docker/config.json ]; then


### PR DESCRIPTION
To improve CI reliability in the case of transient network/GitHub/CDN issues.

Note: The `--max-time` usage is mostly so that jobs don't hang; if a transfer is in progress the repeated payload piped to `tar` won't be a valid archive. However retries will still work for connect timeouts/non-200 http responses (which will likely be the most common failure modes).

Closes #45.