### PR TITLE
Update examples to use a supported builder image

### DIFF
--- a/src/examples/basic.yml
+++ b/src/examples/basic.yml
@@ -9,4 +9,4 @@ usage:
       jobs:
         - buildpacks/build:
             image-name: myimage
-            builder: heroku/buildpacks:18
+            builder: heroku/builder:22

--- a/src/examples/build-and-publish.yml
+++ b/src/examples/build-and-publish.yml
@@ -10,7 +10,7 @@ usage:
         - buildpacks/build:
             image-name: myimage
             image-file: myimage.tgz
-            builder: heroku/buildpacks:18
+            builder: heroku/builder:22
         - publish:
             requires:
               - buildpacks/build

--- a/src/examples/explicit-buildpacks.yml
+++ b/src/examples/explicit-buildpacks.yml
@@ -9,5 +9,5 @@ usage:
       jobs:
         - buildpacks/build:
             image-name: myimage
-            builder: heroku/buildpacks:18
+            builder: heroku/builder:22
             buildpack: heroku/ruby


### PR DESCRIPTION
The `heroku/buildpacks:18` builder image has been EOLed and aborts with an error message.

The examples have been updated to use the newer `heroku/builder:22`.

For all available builder image variants, see:
https://github.com/heroku/cnb-builder-images/blob/main/README.md